### PR TITLE
Tried to apply lemouth's corrections request:

### DIFF
--- a/src/parameter/parameter.py
+++ b/src/parameter/parameter.py
@@ -56,7 +56,7 @@ class ExternParam (PyRuleParam) :
 l    """
     def __init__ (self, 
       value = 1.0, # Real number
-      blockName = 'FRBlock',
+      blockName = 'PyRulesBlock',
       interactionOrder = None,
       orderBlock = None) :
 
@@ -127,14 +127,12 @@ class ExternTensorParam (ExternParam) :
     def __init__ (self,
         indices,
         value,
-        blockName = 'FRBlock',
-        orderBlock = None,
+        blockName,
         complexParameter = True,
         interactionOrder = None, # A 2-tupe (ExternParam, order)
         unitary = False,
         hermitian = False,
-        orthogonal = False,
-        allowSummation = False) :
+        orthogonal = False) :
 
         """
         Parameters
@@ -154,7 +152,6 @@ class ExternTensorParam (ExternParam) :
           True if parameter corresponds to Hermitian matrix
         orthogonal: bool
           True if parameter corresponds to orthogonal matrix
-        allowSummation: bool
         """
 
         self.indices = indices
@@ -162,12 +159,10 @@ class ExternTensorParam (ExternParam) :
         self.unitary = unitary
         self.hermitian = hermitian
         self.orthogonal = orthogonal
-        self.allowSummation = allowSummation
 
         super(ExternTensorParam, self).__init__(value, 
           blockName,
-          interactionOrder,
-          orderBlock)
+          interactionOrder)
 
 class InternTensorParam (ExternParam) :
     """
@@ -181,8 +176,7 @@ class InternTensorParam (ExternParam) :
         parameterName = None,
         unitary = False,
         hermitian = False,
-        orthogonal = False,
-        allowSummation = False) :
+        orthogonal = False) :
 
         """
         Parameters
@@ -203,14 +197,12 @@ class InternTensorParam (ExternParam) :
           True if parameter corresponds to Hermitian matrix
         orthogonal: bool
           True if parameter corresponds to orthogonal matrix
-        allowSummation: bool
         """
 
         self.indices = indices
         self.unitary = unitary
         self.hermitian = hermitian
         self.orthogonal = orthogonal
-        self.allowSummation = allowSummation
 
         super(InternTensorParam, self).__init__(value, 
           complexParameter,


### PR DESCRIPTION
if the Les Houches info is not provided, the parameters have to be included in a freshly created
block. This is implemented and will work fine for scalar parameters where the block FRBlock is assigned. By the way this should become
PyRulesBlock (FRBlock stands for FeynRulesBlock :p). However, for tensor parameters, they must lie in their own block -> a freshly unique name
must be generated. the allowsummation option must disappear. I don’t want it because it is ugly ;) Tensorparameters don’t have any orderblock
attribute, as the orderblocks are ntuples with the line number, column number, etc...